### PR TITLE
Added suppress warnings for InsecureRequestWarning in logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk --no-cache add python py-setuptools py-pip gcc libffi py-cffi python-dev
     pip install requests-aws4auth==0.9 && \
     pip install cryptography==2.1.3 && \
     apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers openssl-dev && \
+    sed -i '/import sys/a urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)' /usr/bin/curator && \
     sed -i '/import sys/a urllib3.contrib.pyopenssl.inject_into_urllib3()' /usr/bin/curator && \
     sed -i '/import sys/a import urllib3.contrib.pyopenssl' /usr/bin/curator && \
     sed -i '/import sys/a import urllib3' /usr/bin/curator


### PR DESCRIPTION
There are a lot of warnings in curator job like this `"InsecureRequestWarning: Unverified HTTPS request is being made..."`
This is expected behavior by https://www.elastic.co/guide/en/elasticsearch/client/curator/current/configfile.html#ssl_no_validate, but it is very annoying, so this fix disabled these warnings, see https://github.com/influxdata/influxdb-python/issues/240#issuecomment-341313420